### PR TITLE
Additions and fixes to support types needed by the VideoPlayer.

### DIFF
--- a/APIHelper.h
+++ b/APIHelper.h
@@ -213,15 +213,20 @@ public:
 
 	inline T* Lock()
 	{
-		T* elements = malloc(Length() * sizeof(T));
+		T* elements = reinterpret_cast<T*>(malloc(Length() * sizeof(T)));
 		for (int i = 0; i < Length(); ++i)
-			elements[i] = T(jni::GetObjectArrayElement(*this, i));
+			new (&(elements[i])) T(jni::GetObjectArrayElement(*this, i));
+
 		return elements;
 	}
 	inline void Release(T* elements)
 	{
 		for (int i = 0; i < Length(); ++i)
+		{
 			jni::SetObjectArrayElement(*this, i, elements[i]);
+			elements[i].~T();
+		}
+
 		free(elements);
 	}
 };

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -377,6 +377,21 @@ void ReleasePrimitiveArrayCritical(jarray obj, void *carray, jint mode)
 	JNI_CALL(obj, false, env->ReleasePrimitiveArrayCritical(obj, carray, mode));
 }
 
+jobject NewDirectByteBuffer(void* buffer, jlong size)
+{
+	JNI_CALL_RETURN(jobject, buffer, true, env->NewDirectByteBuffer(buffer, size));
+}
+
+void* GetDirectBufferAddress(jobject byteBuffer)
+{
+	JNI_CALL_RETURN(void*, byteBuffer, true, env->GetDirectBufferAddress(byteBuffer));
+}
+
+jlong GetDirectBufferCapacity(jobject byteBuffer)
+{
+	JNI_CALL_RETURN(jlong, byteBuffer, true, env->GetDirectBufferCapacity(byteBuffer));
+}
+
 // --------------------------------------------------------------------------------------
 // ThreadScope
 // --------------------------------------------------------------------------------------

--- a/JNIBridge.h
+++ b/JNIBridge.h
@@ -86,6 +86,10 @@ void*        GetPrimitiveArrayCritical(jarray obj, jboolean *isCopy);
 void         ReleasePrimitiveArrayCritical(jarray obj, void *carray, jint mode);
 jobjectArray NewObjectArray(jsize length, jclass elementClass, jobject initialElement = 0);
 
+jobject      NewDirectByteBuffer(void* buffer, jlong size);
+void*        GetDirectBufferAddress(jobject byteBuffer);
+jlong        GetDirectBufferCapacity(jobject byteBuffer);
+
 class ThreadScope
 {
 public:

--- a/build.pl
+++ b/build.pl
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl -w
-
 use PrepareAndroidSDK;
 use File::Path;
 use strict;
@@ -24,6 +23,10 @@ my @classes = (
 	'::android::hardware::GeomagneticField',
 	'::android::location::LocationManager',
 	'::android::media::AudioManager',
+	'::android::media::MediaCodec',
+	'::android::media::MediaCodec::BufferInfo',
+	'::android::media::MediaExtractor',
+	'::android::media::MediaFormat',
 	'::android::media::MediaRouter',
 	'::android::net::ConnectivityManager',
 	'::android::os::Build',


### PR DESCRIPTION
APIHelper.h
--------------------------------------------------------------------------------

Fixed array element initialization/destruction in Array::Lock()/Array::Release()
to support objects.  With ::java::nio::ByteBuffer, assigning to a uninitialized
ByteBuffer crashed because Ref::operator= was dealing with uninitialized data.

JNIBridge.cpp
JNIBridge.h
--------------------------------------------------------------------------------

Added access to JNIEnv methods to support for direct access to ByteBuffer
content.

build.pl
--------------------------------------------------------------------------------

Acced the media classes needed by the VideoPlayer.