### PR TITLE
use Android O (API 26)

### DIFF
--- a/Makefile.android
+++ b/Makefile.android
@@ -1,5 +1,5 @@
 
-APINAME	= android-23
+APINAME	= android-26
 APIJAR	= ${ANDROID_SDK_ROOT}/platforms/${APINAME}/android.jar
 GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar
 

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -39,6 +39,7 @@ our $sdks =
 	"android-19"	=> "android-19_r03.zip",
 	"android-21"	=> "android-21_r02.zip",
 	"android-23"	=> "android-23_r02.zip",
+	"android-26"	=> "platform-26_r02.zip",
 };
 
 our $sdk_tools =

--- a/build.pl
+++ b/build.pl
@@ -4,7 +4,7 @@ use File::Path;
 use strict;
 use warnings;
 
-my $api = "android-23";
+my $api = "android-26";
 
 my @classes = (
 	'::android::Manifest_permission',
@@ -22,6 +22,8 @@ my @classes = (
 	'::android::hardware::input::InputManager',
 	'::android::hardware::GeomagneticField',
 	'::android::location::LocationManager',
+	'::android::media::AudioAttributes_Builder',
+	'::android::media::AudioFocusRequest_Builder',
 	'::android::media::AudioManager',
 	'::android::media::MediaCodec',
 	'::android::media::MediaCodec::BufferInfo',

--- a/templates/android.os.Bundle.cpp
+++ b/templates/android.os.Bundle.cpp
@@ -6,11 +6,6 @@ void Bundle::__Initialize() { }
 // --------------------------------------------------------
 // Copied from android::os::BaseBundle
 // --------------------------------------------------------
-::jvoid Bundle::Remove(const ::java::lang::String& arg0) const
-{
-	static jmethodID methodID = jni::GetMethodID(__CLASS, "remove", "(Ljava/lang/String;)V");
-	return ::jvoid(jni::Op<jvoid>::CallMethod(m_Object, methodID, (jobject)arg0));
-}
 ::java::lang::Object Bundle::Get(const ::java::lang::String& arg0) const
 {
 	static jmethodID methodID = jni::GetMethodID(__CLASS, "get", "(Ljava/lang/String;)Ljava/lang/Object;");

--- a/templates/android.os.Bundle.h
+++ b/templates/android.os.Bundle.h
@@ -4,7 +4,6 @@
 // --------------------------------------------------------
 // Copied from android::os::BaseBundle
 // --------------------------------------------------------
-::jvoid Remove(const ::java::lang::String& arg0) const;
 ::java::lang::Object Get(const ::java::lang::String& arg0) const;
 ::jboolean GetBoolean(const ::java::lang::String& arg0) const;
 ::jboolean GetBoolean(const ::java::lang::String& arg0, const ::jboolean& arg1) const;


### PR DESCRIPTION
* Upgrading jni bridge generation to include Android API 26.
* In API 26 there is a new method https://developer.android.com/reference/android/content/ServiceConnection.html#onBindingDied(android.content.ComponentName) added to one of the interfaces. Because of this method binding had to be changed from a static to a lazy approach.
* Including ::android::media::AudioAttributes_Builder and ::android::media::AudioFocusRequest_Builder to generated api because they both are needed since Android API 26 to request audio focus.
* removing "::jvoid Remove(const ::java::lang::String& arg0) const;" because this method is present in ::android::os::Bundle, so it would appear twice in API.h in Bundle class otherwise.