### PR TITLE
Add WifiManager to JNI bridge classes

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -31,6 +31,7 @@ my @classes = (
 	'::android::media::MediaFormat',
 	'::android::media::MediaRouter',
 	'::android::net::ConnectivityManager',
+	'::android::net::wifi::WifiManager',
 	'::android::os::Build',
 	'::android::os::Build_VERSION',
 	'::android::os::HandlerThread',


### PR DESCRIPTION
This is needed to acquire/release the multicast lock which is used to receive broadcast packets.