### PR TITLE
Clear errors before pushing new frame

### DIFF
--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -411,6 +411,7 @@ ThreadScope::~ThreadScope()
 // --------------------------------------------------------------------------------------
 LocalFrame::LocalFrame(jint capacity)
 {
+	ClearErrors();
 	if (PushLocalFrame(capacity) < 0)
 		FatalError("Out of memory: Unable to allocate local frame(64)");
 	m_FramePushed = (PeekError() == kJNI_NO_ERROR);


### PR DESCRIPTION
If local frame is create when error flag is present, it will assume new frame is not pushed. Need to clear error first, so that after PushLocalFrame() error flag represents the actual result of frame push.