### PR TITLE
Use Android P (API 28)

### DIFF
--- a/Makefile.android
+++ b/Makefile.android
@@ -1,5 +1,5 @@
 
-APINAME	= android-26
+APINAME	= android-28
 APIJAR	= ${ANDROID_SDK_ROOT}/platforms/${APINAME}/android.jar
 GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services_froyo/libproject/google-play-services_lib/libs/google-play-services.jar
 

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -46,30 +46,31 @@ our $sdks =
     "android-21" => "android-21_r02.zip",
     "android-23" => "android-23_r02.zip",
     "android-26" => "platform-26_r02.zip",
+    "android-28" => "platform-28_r06.zip",
     };
 
 our $sdk_tools =
     {
-    "version" => "24.4.1",
-    "windows" => "tools_r24.4.1-windows.zip",
-    "linux"   => "tools_r24.4.1-linux.zip",
-    "macosx"  => "tools_r24.4.1-macosx.zip",
+    "version" => "26.1.1",
+    "windows" => "sdk-tools-windows-4333796.zip",
+    "linux"   => "sdk-tools-linux-4333796.zip",
+    "macosx"  => "sdk-tools-darwin-4333796.zip",
     };
 
 our $platform_tools =
     {
-    "version" => "23.1.0",
-    "windows" => "platform-tools_r23.1.0-windows.zip",
-    "linux"   => "platform-tools_r23.1.0-linux.zip",
-    "macosx"  => "platform-tools_r23.1.0-macosx.zip",
+    "version" => "28.0.1",
+    "windows" => "platform-tools_r28.0.1-windows.zip",
+    "linux"   => "platform-tools_r28.0.1-linux.zip",
+    "macosx"  => "platform-tools_r28.0.1-darwin.zip",
     };
 
 our $build_tools =
     {
-    "version" => "25.0.2",
-    "windows" => "build-tools_r25.0.2-windows.zip",
-    "linux"   => "build-tools_r25.0.2-linux.zip",
-    "macosx"  => "build-tools_r25.0.2-macosx.zip",
+    "version" => "28.0.2",
+    "windows" => "build-tools_r28.0.2-windows.zip",
+    "linux"   => "build-tools_r28.0.2-linux.zip",
+    "macosx"  => "build-tools_r28.0.2-macosx.zip",
     };
 
 our $gpss =

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -67,10 +67,10 @@ our $platform_tools =
 
 our $build_tools =
     {
-    "version" => "28.0.2",
-    "windows" => "build-tools_r28.0.2-windows.zip",
-    "linux"   => "build-tools_r28.0.2-linux.zip",
-    "macosx"  => "build-tools_r28.0.2-macosx.zip",
+    "version" => "28.0.3",
+    "windows" => "build-tools_r28.0.3-windows.zip",
+    "linux"   => "build-tools_r28.0.3-linux.zip",
+    "macosx"  => "build-tools_r28.0.3-macosx.zip",
     };
 
 our $gpss =

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -27,7 +27,6 @@ our $NDK_ROOT_ENV = "ANDROID_NDK_ROOT";
 # and sdk tools on https://developer.android.com/studio/#downloads
 
 our $BASE_URL_SDK = "http://dl.google.com/android/repository/";
-our $BASE_URL_NDK = "http://dl.google.com/android/repository/";
 
 our $sdks =
     {
@@ -86,96 +85,6 @@ our $gpss =
 
 our $ndks =
     {
-    "r5" =>
-        {
-        "windows" => "android-ndk-r5-windows.zip",
-        "macosx"  => "android-ndk-r5-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r5-linux-x86.tar.bz2",
-        },
-    "r5b" =>
-        {
-        "windows" => "android-ndk-r5b-windows.zip",
-        "macosx"  => "android-ndk-r5b-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r5b-linux-x86.tar.bz2",
-        },
-    "r5c" =>
-        {
-        "windows" => "android-ndk-r5c-windows.zip",
-        "macosx"  => "android-ndk-r5c-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r5c-linux-x86.tar.bz2",
-        },
-    "r6" =>
-        {
-        "windows" => "android-ndk-r6-windows.zip",
-        "macosx"  => "android-ndk-r6-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r6-linux-x86.tar.bz2",
-        },
-    "r6b" =>
-        {
-        "windows" => "android-ndk-r6b-windows.zip",
-        "macosx"  => "android-ndk-r6b-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r6b-linux-x86.tar.bz2",
-        },
-    "r7" =>
-        {
-        "windows" => "android-ndk-r7-windows.zip",
-        "macosx"  => "android-ndk-r7-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r7-linux-x86.tar.bz2",
-        },
-    "r7b" =>
-        {
-        "windows" => "android-ndk-r7b-windows.zip",
-        "macosx"  => "android-ndk-r7b-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r7b-linux-x86.tar.bz2",
-        },
-    "r7c" =>
-        {
-        "windows" => "android-ndk-r7c-windows.zip",
-        "macosx"  => "android-ndk-r7c-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r7c-linux-x86.tar.bz2",
-        },
-    "r8" =>
-        {
-        "windows" => "android-ndk-r8-windows.zip",
-        "macosx"  => "android-ndk-r8-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r8-linux-x86.tar.bz2",
-        },
-    "r8b" =>
-        {
-        "windows" => "android-ndk-r8b-windows.zip",
-        "macosx"  => "android-ndk-r8b-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r8b-linux-x86.tar.bz2",
-        },
-    "r8c" =>
-        {
-        "windows" => "android-ndk-r8c-windows.zip",
-        "macosx"  => "android-ndk-r8c-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r8c-linux-x86.tar.bz2",
-        },
-    "r8e" =>
-        {
-        "windows" => "android-ndk-r8e-windows.zip",
-        "macosx"  => "android-ndk-r8e-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r8e-linux-x86.tar.bz2",
-        },
-    "r9" =>
-        {
-        "windows" => "android-ndk-r9-windows-x86.zip",
-        "macosx"  => "android-ndk-r9-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk-r9-linux-x86.tar.bz2",
-        },
-    "r10b" =>
-        {
-        "windows" => "android-ndk32-r10b-windows-x86.zip",
-        "macosx"  => "android-ndk32-r10b-darwin-x86.tar.bz2",
-        "linux"   => "android-ndk32-r10b-linux-x86.tar.bz2",
-        },
-    "r10e" =>
-        {
-        "windows" => "android-ndk-r10e-windows-x86_64.exe",
-        "macosx"  => "android-ndk-r10e-darwin-x86_64.bin",
-        "linux"   => "android-ndk-r10e-linux-x86_64.bin",
-        },
     "r13b" =>
         {
         "windows" => "android-ndk-r13b-windows-x86_64.zip",
@@ -627,14 +536,7 @@ sub PrepareNDK
     die("Unknown NDK release '$ndk' (for $HOST_ENV)") if (!$archive);
 
     print "\tDownloading '$ndk' to '$ndk_root'\n";
-    if ($ndk =~ m/r13/ or $ndk =~ m/r16/ or $ndk =~ m/r17/)
-    {
-        DownloadAndUnpackArchive($BASE_URL_SDK . $archive, $ndk_root);
-    }
-    else
-    {
-        DownloadAndUnpackArchive($BASE_URL_NDK . $archive, $ndk_root);
-    }
+    DownloadAndUnpackArchive($BASE_URL_SDK . $archive, $ndk_root);
 }
 
 1;

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -23,10 +23,11 @@ our @EXPORT_OK = qw(GetAndroidSDK);
 our $SDK_ROOT_ENV = "ANDROID_SDK_ROOT";
 our $NDK_ROOT_ENV = "ANDROID_NDK_ROOT";
 
-# based on https://dl.google.com/android/repository/repository-11.xml
+# based on https://dl.google.com/android/repository/repository-12.xml
+# and sdk tools on https://developer.android.com/studio/#downloads
 
 our $BASE_URL_SDK = "http://dl.google.com/android/repository/";
-our $BASE_URL_NDK = "http://dl.google.com/android/ndk/";
+our $BASE_URL_NDK = "http://dl.google.com/android/repository/";
 
 our $sdks =
     {

--- a/build.pl
+++ b/build.pl
@@ -4,7 +4,7 @@ use File::Path;
 use strict;
 use warnings;
 
-my $api = "android-26";
+my $api = "android-28";
 
 my @classes = (
 	'::android::Manifest_permission',


### PR DESCRIPTION
* Upgrading jni bridge generation to include Android API 28.
* In API 28 there is a new method https://developer.android.com/reference/android/content/ServiceConnection#onNullBinding(android.content.ComponentName)

Recent [PR ](https://github.com/Unity-Technologies/android-jni-bridge/pull/20) uncovered unhandled MethodNotFoundException (https://developer.android.com/reference/android/content/ServiceConnection#onBindingDied(android.content.ComponentName)) when running on devices with API <26. Same will affect this PR when running on devices with API <28, with exception of not finding `ServiceConnection#onNullBinding`