### PR TITLE
Fix PushLocalFrame logic

### DIFF
--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -411,15 +411,9 @@ ThreadScope::~ThreadScope()
 // --------------------------------------------------------------------------------------
 LocalFrame::LocalFrame(jint capacity)
 {
-	if (PeekError() != kJNI_NO_ERROR)
-	{
-		FatalError("Pushing new local frame with error present");
-		m_FramePushed = false;
-		return;
-	}
-	if (PushLocalFrame(capacity) < 0)
+	m_FramePushed = PushLocalFrame(capacity) == 0;
+	if (!m_FramePushed)
 		FatalError("Out of memory: Unable to allocate local frame(64)");
-	m_FramePushed = (PeekError() == kJNI_NO_ERROR);
 }
 LocalFrame::~LocalFrame()
 {


### PR DESCRIPTION
Previous changes to LocalFrame were wrong since LocalFrame was always pushed when the error was being detected. There were no "hidden" errors that were missed by pushing LocalFrame.
According to android documentation https://developer.android.com/training/articles/perf-jni#exceptions PushLocalFrame can be called with a pending exception, so there is no need to do any exception clearing in the LocalFrame either.
There was another logical problem that we considered a LocalFrame pushed only when there was no errors, however since LocalFrame was also pushed when the exception was detected, some of the successfully pushed local frames were never popped and that was causing a crash on some older devices. By making sure that all pushed local frames are popped later on the crash on Android 4.x devices was gone.