### PR TITLE
Added partial Android API 28 support for 2017.4

### DIFF
--- a/Makefile.android
+++ b/Makefile.android
@@ -1,5 +1,5 @@
 
-APINAME	= android-26
+APINAME	= android-28
 APIJAR	= ${ANDROID_SDK_ROOT}/platforms/${APINAME}/android.jar
 GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar
 

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -40,30 +40,31 @@ our $sdks =
 	"android-21"	=> "android-21_r02.zip",
 	"android-23"	=> "android-23_r02.zip",
 	"android-26"	=> "platform-26_r02.zip",
+    "android-28"    => "platform-28_r06.zip",
 };
 
 our $sdk_tools =
 {
-	"version"		=> "24.4.1",
-	"windows"		=> "tools_r24.4.1-windows.zip",
-	"linux"			=> "tools_r24.4.1-linux.zip",
-	"macosx"		=> "tools_r24.4.1-macosx.zip",
+	"version"   => "26.1.1",
+    "windows"   => "sdk-tools-windows-4333796.zip",
+    "linux"     => "sdk-tools-linux-4333796.zip",
+    "macosx"    => "sdk-tools-darwin-4333796.zip",
 };
 
 our $platform_tools =
 {
-	"version"		=> "23.1.0",
-	"windows"		=> "platform-tools_r23.1.0-windows.zip",
-	"linux"			=> "platform-tools_r23.1.0-linux.zip",
-	"macosx"		=> "platform-tools_r23.1.0-macosx.zip",
+    "version" => "28.0.1",
+    "windows" => "platform-tools_r28.0.1-windows.zip",
+    "linux"   => "platform-tools_r28.0.1-linux.zip",
+    "macosx"  => "platform-tools_r28.0.1-darwin.zip",
 };
 
 our $build_tools =
 {
-	"version"		=> "23.0.2",
-	"windows"		=> "build-tools_r23.0.2-windows.zip",
-	"linux"			=> "build-tools_r23.0.2-linux.zip",
-	"macosx"		=> "build-tools_r23.0.2-macosx.zip",
+    "version" => "28.0.3",
+    "windows" => "build-tools_r28.0.3-windows.zip",
+    "linux"   => "build-tools_r28.0.3-linux.zip",
+    "macosx"  => "build-tools_r28.0.3-macosx.zip",
 };
 
 our $ndks =

--- a/build.pl
+++ b/build.pl
@@ -4,7 +4,7 @@ use File::Path;
 use strict;
 use warnings;
 
-my $api = "android-26";
+my $api = "android-28";
 
 my @classes = (
 	'::android::Manifest_permission',


### PR DESCRIPTION
Upgrading JNI bridge generation to include Android API 28.
In API 28 there is a new method https://developer.android.com/reference/android/content/ServiceConnection#onNullBinding(android.content.ComponentName)

This is a partial update without full support for Android API 28, specifically for adding support for this new method to 2017.4.