### PR TITLE
Allow manually destroying all JNI proxies

### DIFF
--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -4,7 +4,7 @@ namespace jni
 {
 
 jni::Class s_JNIBridgeClass("bitter/jnibridge/JNIBridge");
-ProxyTracker::LinkedProxy* ProxyTracker::head = NULL;
+ProxyTracker ProxyObject::proxyTracker;
 
 JNIEXPORT jobject JNICALL Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_invoke(JNIEnv* env, jobject thiz, jlong ptr, jclass clazz, jobject method, jobjectArray args)
 {
@@ -63,6 +63,11 @@ jobject ProxyObject::__Invoke(jclass clazz, jmethodID mid, jobjectArray args)
 	return result;
 }
 
+void ProxyObject::DeleteAllProxies()
+{
+	proxyTracker.DeleteAllProxies();
+}
+
 bool ProxyObject::__TryInvoke(jclass clazz, jmethodID methodID, jobjectArray args, bool* success, jobject* result)
 {
 	if (*success)
@@ -96,6 +101,65 @@ void ProxyObject::DisableInstance(jobject proxy)
 {
 	static jmethodID disableProxyMID = jni::GetStaticMethodID(s_JNIBridgeClass, "disableInterfaceProxy", "(Ljava/lang/Object;)V");
 	jni::Op<jvoid>::CallStaticMethod(s_JNIBridgeClass, disableProxyMID, proxy);
+}
+
+ProxyTracker::ProxyTracker()
+{
+	pthread_mutexattr_t attr;
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	pthread_mutex_init(&lock, &attr);
+	pthread_mutexattr_destroy(&attr);
+	head = NULL;
+}
+
+ProxyTracker::~ProxyTracker()
+{
+	pthread_mutex_destroy(&lock);
+}
+
+void ProxyTracker::StartTracking(ProxyObject* obj)
+{
+	pthread_mutex_lock(&lock);
+	head = new LinkedProxy(obj, head);
+	pthread_mutex_unlock(&lock);
+}
+
+void ProxyTracker::StopTracking(ProxyObject* obj)
+{
+	pthread_mutex_lock(&lock);
+	LinkedProxy* current = head;
+	LinkedProxy* previous = NULL;
+	while (current != NULL && current->obj != obj)
+	{
+		previous = current;
+		current = current->next;
+	}
+
+	if (current != NULL)
+	{
+		if (previous == NULL)
+			head = current->next;
+		else
+			previous->next = current->next;
+		delete current;
+	}
+	pthread_mutex_unlock(&lock);
+}
+
+void ProxyTracker::DeleteAllProxies()
+{
+	pthread_mutex_lock(&lock);
+	LinkedProxy* current = head;
+	head = NULL; // Destructor will call StopTracking, this will prevent it from looping through the whole list
+	while (current != NULL)
+	{
+		LinkedProxy* previous = current;
+		current = current->next;
+		delete previous->obj;
+		delete previous;
+	}
+	pthread_mutex_unlock(&lock);
 }
 
 }

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -4,6 +4,7 @@ namespace jni
 {
 
 jni::Class s_JNIBridgeClass("bitter/jnibridge/JNIBridge");
+ProxyTracker::LinkedProxy* ProxyTracker::head = NULL;
 
 JNIEXPORT jobject JNICALL Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_invoke(JNIEnv* env, jobject thiz, jlong ptr, jclass clazz, jobject method, jobjectArray args)
 {

--- a/Proxy.h
+++ b/Proxy.h
@@ -26,14 +26,76 @@ protected:
 	static void    DisableInstance(jobject proxy);
 };
 
+
+class ProxyTracker 
+{
+public:
+	static void StartTracking(ProxyObject* obj)
+	{
+		head = new LinkedProxy(obj, head);
+	}
+
+	static void StopTracking(ProxyObject* obj)
+	{
+		LinkedProxy* current = head;
+		LinkedProxy* previous = NULL;
+		while (current != NULL && current->obj != obj)
+		{
+			previous = current;
+			current = current->next;
+		}
+
+		if (current != NULL)
+		{
+			if (previous == NULL)
+				head = current->next;
+			else
+				previous->next = current->next;
+			delete current;
+		}
+	}
+
+	static void DeleteAllProxies()
+	{
+		LinkedProxy* current = head;
+		head = NULL; // Destructor will call StopTracking, this will prevent it from looping through the whole list
+		while (current != NULL)
+		{
+			LinkedProxy* previous = current;
+			current = current->next;
+			delete previous->obj;
+			delete previous;
+		}
+	}
+private:
+	class LinkedProxy
+	{
+	public:
+		LinkedProxy(ProxyObject* target, LinkedProxy* link)
+		{
+			obj = target;
+			next = link;
+		}
+
+		ProxyObject* obj;
+		LinkedProxy* next;
+	};
+
+	static LinkedProxy* head;
+};
+
 template <class RefAllocator, class ...TX>
 class ProxyGenerator : public ProxyObject, public TX::__Proxy...
-{
+{	
 protected:
-	ProxyGenerator() : m_ProxyObject(NewInstance(this, (jobject[]){TX::__CLASS...}, sizeof...(TX)))	{ }
+	ProxyGenerator() : m_ProxyObject(NewInstance(this, (jobject[]){TX::__CLASS...}, sizeof...(TX)))	
+	{
+		ProxyTracker::StartTracking(this);
+	}
 
 	virtual ~ProxyGenerator()
 	{
+		ProxyTracker::StopTracking(this);
 		DisableInstance(__ProxyObject());
 	}
 


### PR DESCRIPTION
Provide a way of destroying all JNI proxies. This should be used when unloading.

This fixes the problem where java could sometimes try and delete some native proxy object that has been unloaded, causing a crash.