### PR TITLE
Acd move semantics

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -1,14 +1,37 @@
-name: Build JNIBridge
-
-agent:
-  type: Unity::VM::osx
-  image: build-system/unity-extra-macos-10.13-katana:v0.3.6-621005
-  flavor: b1.xlarge
-
-commands:
-  - perl build.pl
-
-artifacts:
+build_for_android:
+  name: Build JNIBridge
+  agent:
+    type: Unity::VM::osx
+    image: build-system/unity-extra-macos-10.13-katana:v0.3.6-621005
+    flavor: b1.xlarge
+  commands:
+    - perl build.pl
   artifacts:
-    paths:
-      - build/builds.zip
+    artifacts:
+      paths:
+        - build/builds.zip
+
+test_on_osx:
+  name: Test on OSX
+  agent:
+    type: Unity::VM::osx
+    image: build-system/unity-extra-macos-10.13-katana:v0.3.6-621005
+    flavor: b1.xlarge
+  commands:
+    - perl build-osx.pl
+    - make -f test/Makefile
+
+test_trigger:
+  name: Tests Trigger
+  agent:
+    type: Unity::VM::osx
+    image: build-system/unity-extra-macos-10.13-katana:v0.3.6-621005
+    flavor: b1.xlarge
+  commands:
+    - dir
+  triggers:
+    branches:
+      only:
+        - "/.*/"
+  dependencies:
+    - .yamato/build.yml#test_on_osx

--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -28,7 +28,7 @@ test_trigger:
     image: build-system/unity-extra-macos-10.13-katana:v0.3.6-621005
     flavor: b1.xlarge
   commands:
-    - dir
+    - true
   triggers:
     branches:
       only:

--- a/APIGenerator.java
+++ b/APIGenerator.java
@@ -613,9 +613,6 @@ public class APIGenerator
 			getSimpleName(clazz),
 			getSuperClassName(clazz),
 			hasTemplate ? " __Initialize(); " : "");
-		out.format("\t%s(%s&& o) = default;\n",
-			getSimpleName(clazz),
-			getSimpleName(clazz));
 		if (hasTemplate)
 		{
 			out.format("%s\n",	new Scanner(templateFile).useDelimiter("\\Z").next());
@@ -624,6 +621,10 @@ public class APIGenerator
 		}
 		else
 		{
+			// Move constructor
+			out.format("\t%s(%s&& o) = default;\n",
+				getSimpleName(clazz),
+				getSimpleName(clazz));
 			// Standard assignment operators
 			out.format("\t%s& operator=(const %s& o) = default;\n",
 				getSimpleName(clazz),

--- a/APIGenerator.java
+++ b/APIGenerator.java
@@ -471,6 +471,7 @@ public class APIGenerator
 		for (Class clazz : m_VisitedClasses)
 		{
 			PrintStream source = new PrintStream(new FileOutputStream(new File(dst, clazz.getCanonicalName() + ".cpp")));
+			source.format("#include <utility>\n");
 			source.format("#include \"API.h\"\n");
 			implementClass(source, clazz);
 			source.close();

--- a/APIGenerator.java
+++ b/APIGenerator.java
@@ -613,11 +613,24 @@ public class APIGenerator
 			getSimpleName(clazz),
 			getSuperClassName(clazz),
 			hasTemplate ? " __Initialize(); " : "");
+		out.format("\t%s(%s&& o) = default;\n",
+			getSimpleName(clazz),
+			getSimpleName(clazz));
 		if (hasTemplate)
 		{
 			out.format("%s\n",	new Scanner(templateFile).useDelimiter("\\Z").next());
 			out.format("private:\n");
 			out.format("\tvoid __Initialize();\n");
+		}
+		else
+		{
+			// Standard assignment operators
+			out.format("\t%s& operator=(const %s& o) = default;\n",
+				getSimpleName(clazz),
+				getSimpleName(clazz));
+			out.format("\t%s& operator=(%s&& o) = default;\n",
+				getSimpleName(clazz),
+				getSimpleName(clazz));
 		}
 		out.format("\n");
 	}

--- a/APIGenerator.java
+++ b/APIGenerator.java
@@ -471,7 +471,6 @@ public class APIGenerator
 		for (Class clazz : m_VisitedClasses)
 		{
 			PrintStream source = new PrintStream(new FileOutputStream(new File(dst, clazz.getCanonicalName() + ".cpp")));
-			source.format("#include <utility>\n");
 			source.format("#include \"API.h\"\n");
 			implementClass(source, clazz);
 			source.close();

--- a/APIHelper.h
+++ b/APIHelper.h
@@ -25,9 +25,10 @@ class Ref
 public:
 	Ref(ObjType object) { m_Ref = new RefCounter(object); }
 	Ref(const Ref<RefType,ObjType>& o) { Aquire(o.m_Ref); }
+	Ref(Ref<RefType, ObjType>&& o) : m_Ref(o.m_Ref) { o.m_Ref = nullptr; }
 	~Ref() { Release(); }
 
-	inline operator ObjType() const	{ return *m_Ref; }
+	inline operator ObjType() const	{ return m_Ref ? static_cast<ObjType>(*m_Ref) : static_cast<ObjType>(0); }
 	Ref<RefType,ObjType>& operator = (const Ref<RefType,ObjType>& o)
 	{
 		if (m_Ref == o.m_Ref)
@@ -36,6 +37,15 @@ public:
 		Release();
 		Aquire(o.m_Ref);
 
+		return *this;
+	}
+	Ref<RefType, ObjType>& operator= (Ref<RefType, ObjType>&& o)
+	{
+		if (m_Ref == o.m_Ref)
+			return *this;
+
+		m_Ref = o.m_Ref;
+		o.m_Ref = nullptr;
 		return *this;
 	}
 
@@ -72,7 +82,7 @@ private:
 
 	void Release()
 	{
-		if (!m_Ref->Release())
+		if (m_Ref && !m_Ref->Release())
 		{
 			delete m_Ref;
 			m_Ref = NULL;

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ JAVAFLAGS	= -XX:MaxPermSize=128M
 JAVACFLAGS  = -source 1.8 -target 1.8
 
 # We use -O2 as it produces smaller size than the -Os. Tested with NDKr19.
-CPPFLAGS	+= -g0 -O2 -Wall -Werror -Wno-long-long -std=c++11 -fno-addrsig
+CPPFLAGS	+= -g0 -O2 -Wall -Werror -Wno-long-long -std=c++11
 
 BUILDDIR	= build
 GENDIR		= ${BUILDDIR}/${APINAME}/source

--- a/Makefile.android
+++ b/Makefile.android
@@ -53,7 +53,7 @@ GCC_TOOL_PREFIX        = ${GCC_TOOLCHAIN_PATH}/bin/${TRIPLE}-
 CPPSYSROOT             = ${NDK}/sysroot
 ISYSTEM                = ${CPPSYSROOT}/usr/include/${TRIPLE}
 LDSYSROOT              = ${NDK}/platforms/${API}/${NDK_ARCH}
-CPPFLAGS              := ${CPPFLAGS} --sysroot=${CPPSYSROOT} -I${ISYSTEM} -fpic -ffunction-sections -fdata-sections -fstrict-aliasing -fvisibility=hidden -MMD
+CPPFLAGS              := ${CPPFLAGS} --sysroot=${CPPSYSROOT} -I${ISYSTEM} -fpic -fno-addrsig -ffunction-sections -fdata-sections -fstrict-aliasing -fvisibility=hidden -MMD
 CXXFLAGS              := ${CXXFLAGS} -fno-rtti -fno-exceptions
 LDFLAGS               := ${LDFLAGS} --sysroot=${LDSYSROOT} -Wl,--no-undefined -Wl,--gc-sections
 CXX                    = ${LLVM_TOOL_PREFIX}clang++ ${DEFINES} ${LLVM_FLAGS}

--- a/build-osx.pl
+++ b/build-osx.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl -w
 
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use PrepareAndroidSDK;
 use File::Path;
 use strict;

--- a/templates/android.os.Bundle.h
+++ b/templates/android.os.Bundle.h
@@ -4,6 +4,8 @@
 // --------------------------------------------------------
 // Copied from android::os::BaseBundle
 // --------------------------------------------------------
+Bundle& operator=(const Bundle& o) = default;
+Bundle& operator=(Bundle&& o) = default;
 ::java::lang::Object Get(const ::java::lang::String& arg0) const;
 ::jboolean GetBoolean(const ::java::lang::String& arg0) const;
 ::jboolean GetBoolean(const ::java::lang::String& arg0, const ::jboolean& arg1) const;

--- a/templates/android.os.Bundle.h
+++ b/templates/android.os.Bundle.h
@@ -4,6 +4,7 @@
 // --------------------------------------------------------
 // Copied from android::os::BaseBundle
 // --------------------------------------------------------
+Bundle(Bundle&& o) = default;
 Bundle& operator=(const Bundle& o) = default;
 Bundle& operator=(Bundle&& o) = default;
 ::java::lang::Object Get(const ::java::lang::String& arg0) const;

--- a/templates/android.view.Display.h
+++ b/templates/android.view.Display.h
@@ -1,2 +1,4 @@
+Display& operator=(const Display& o) = default;
+Display& operator=(Display&& o) = default;
 jint __GetRawWidth() const;
 jint __GetRawHeight() const;

--- a/templates/android.view.Display.h
+++ b/templates/android.view.Display.h
@@ -1,3 +1,4 @@
+Display(Display&& o) = default;
 Display& operator=(const Display& o) = default;
 Display& operator=(Display&& o) = default;
 jint __GetRawWidth() const;

--- a/templates/java.lang.CharSequence.h
+++ b/templates/java.lang.CharSequence.h
@@ -1,3 +1,4 @@
+CharSequence(CharSequence&& o) = default;
 CharSequence(const char* str);
 CharSequence& operator=(const CharSequence& o) = default;
 CharSequence& operator=(CharSequence&& o) = default;

--- a/templates/java.lang.CharSequence.h
+++ b/templates/java.lang.CharSequence.h
@@ -1,1 +1,3 @@
 CharSequence(const char* str);
+CharSequence& operator=(const CharSequence& o) = default;
+CharSequence& operator=(CharSequence&& o) = default;

--- a/templates/java.lang.Number.h
+++ b/templates/java.lang.Number.h
@@ -1,3 +1,4 @@
+Number(Number&& o) = default;
 Number& operator=(const Number& o) = default;
 Number& operator=(Number&& o) = default;
 operator ::jbyte() const;

--- a/templates/java.lang.Number.h
+++ b/templates/java.lang.Number.h
@@ -1,4 +1,5 @@
-
+Number& operator=(const Number& o) = default;
+Number& operator=(Number&& o) = default;
 operator ::jbyte() const;
 operator ::jshort() const;
 operator ::jint() const;

--- a/templates/java.lang.String.cpp
+++ b/templates/java.lang.String.cpp
@@ -38,6 +38,9 @@ String& String::operator = (const String& other)
 
 String& String::operator = (String&& other)
 {
+	if (&other == this)
+		return *this;
+
 	if (m_Str)
 		jni::ReleaseStringUTFChars(*this, m_Str);
 	m_Str = other.m_Str;

--- a/templates/java.lang.String.cpp
+++ b/templates/java.lang.String.cpp
@@ -29,6 +29,16 @@ String& String::operator = (const String& other)
 	return *this;
 }
 
+String& String::operator = (String&& other)
+{
+	if (m_Str)
+		jni::ReleaseStringUTFChars(*this, m_Str);
+	m_Str = other.m_Str;
+	other.m_Str = 0;
+	m_Object = std::move(other.m_Object);
+	return *this;
+}
+
 const char* String::c_str()
 {
 	if (m_Object && !m_Str)

--- a/templates/java.lang.String.cpp
+++ b/templates/java.lang.String.cpp
@@ -35,7 +35,7 @@ String& String::operator = (String&& other)
 		jni::ReleaseStringUTFChars(*this, m_Str);
 	m_Str = other.m_Str;
 	other.m_Str = 0;
-	m_Object = std::move(other.m_Object);
+	m_Object = static_cast<jni::Ref<jni::GlobalRefAllocator, jobject>&&>(other.m_Object);
 	return *this;
 }
 

--- a/templates/java.lang.String.cpp
+++ b/templates/java.lang.String.cpp
@@ -1,3 +1,10 @@
+String::String(String&& o)
+	: Object(static_cast<Object&&>(o))
+	, m_Str(o.m_Str)
+{
+	o.m_Str = 0;
+}
+
 String::String(const char* str) : ::java::lang::Object(str ? jni::NewStringUTF(str) : NULL) { __Initialize(); }
 String::~String()
 {

--- a/templates/java.lang.String.h
+++ b/templates/java.lang.String.h
@@ -1,3 +1,4 @@
+String(String&& o);
 String(const char* str);
 ~String();
 

--- a/templates/java.lang.String.h
+++ b/templates/java.lang.String.h
@@ -2,6 +2,7 @@ String(const char* str);
 ~String();
 
 String& operator = (const String& other);
+String& operator = (String&& other);
 bool EmptyOrNull();
 
 const char* c_str();

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,9 +2,9 @@ JAVA_HOME ?= $(shell /usr/libexec/java_home -v 1.7)
 
 OBJDIR    := build
 
-CPPFLAGS  := ${CPPFLAGS} -Iinclude -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin -std=c++11 -Wall -Werror
+CPPFLAGS  := ${CPPFLAGS} -Ibuild/jdk-7/source -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin -std=c++11 -Wall -Werror
 CXXFLAGS  := ${CXXFLAGS} -fno-rtti -fno-exceptions -g
-LDFLAGS   := ${LDFLAGS} -L${OBJDIR} -Ldarwin -ljdk-7-jni -ljvm -L${JAVA_HOME}/jre/lib/server -Wl,-rpath,${JAVA_HOME}/jre/lib/server
+LDFLAGS   := ${LDFLAGS} -L${OBJDIR}/jdk-7/darwin -ljdk-7-jni -ljvm -L${JAVA_HOME}/jre/lib/server -Wl,-rpath,${JAVA_HOME}/jre/lib/server
 SRCS      := $(wildcard *.cpp)
 OBJS      := $(addprefix $(OBJDIR)/,$(SRCS:%.cpp=%.o))
 
@@ -13,8 +13,11 @@ LD         = g++ ${LDFLAGS}
 all: ${OBJDIR}/test
 	${OBJDIR}/test
 
-${OBJDIR}/test: ${OBJS}
+${OBJDIR}/test: ${OBJS} ${OBJDIR}/Test.o
 	${LD} ${LDFLAGS} -o $@ $^
+
+${OBJDIR}/Test.o: test/Test.cpp
+	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 
 ${OBJDIR}/%.o: %.cpp
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <utility>
 
 #include "API.h"
 #include "Proxy.h"
@@ -327,6 +328,39 @@ int main(int,char**)
 		printf("equals: %d\n", runnable.Equals(runnable));
 		printf("hashcode: %d\n", runnable.HashCode());
 		printf("toString: %s\n", runnable.ToString().c_str());
+	}
+
+
+	// -------------------------------------------------------------
+	// Move semantics
+	// -------------------------------------------------------------
+	{
+		jni::LocalFrame frame;
+
+		java::lang::Integer integer(1234);
+		java::lang::Integer integer_moved(std::move(integer));
+
+		if (static_cast<jobject>(integer) != 0)
+		{
+			puts("Interger was supposed to be moved from!!!!");
+			abort();
+		}
+
+		printf("Value of moved integer: %d\n", static_cast<jint>(integer_moved));
+
+		java::lang::Integer integer_assigned(4321);
+		integer_assigned = std::move(integer_moved);
+
+		if (static_cast<jobject>(integer_moved) != 0)
+		{
+			puts("integer_moved was supposed to be moved from when assigning!!!!");
+			abort();
+		}
+
+		printf("Value of move-assigned integer: %d\n", static_cast<jint>(integer_assigned));
+
+		integer = integer_assigned;
+		printf("Value of copy-assigned integer: %d\n", static_cast<jint>(integer));
 	}
 
 	printf("%s\n", "EOP");

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -375,13 +375,23 @@ int main(int,char**)
 		java::lang::String str_moved("other");
 		str_moved = std::move(str);
 
-		if (static_cast<jobject>(str) != 0)
+		if (static_cast<jobject>(str) != 0 || str.c_str() != nullptr)
 		{
 			puts("str was supposed to be moved from when assigning");
 			abort();
 		}
 
 		printf("Moved string: %s\n", str_moved.c_str());
+
+		java::lang::String str_ctor_moved(std::move(str_moved));
+
+		if (static_cast<jobject>(str_moved) != 0 || str_moved.c_str() != nullptr)
+		{
+			puts("str_moved was supposed to be moved from when assigning");
+			abort();
+		}
+
+		printf("Moved string via constructor: %s\n", str_ctor_moved.c_str());
 	}
 
 	printf("%s\n", "EOP");

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -16,7 +16,7 @@ int main(int,char**)
 	JavaVMInitArgs vm_args;
 	memset(&vm_args, 0, sizeof(vm_args));
 
-	char classPath[] = {"-Djava.class.path=../build"};
+	char classPath[] = {"-Djava.class.path=build"};
 
 	JavaVMOption options[1];
 	options[0].optionString = classPath;
@@ -276,6 +276,11 @@ int main(int,char**)
 			virtual ::java::lang::Object Next()
 			{
 				return ::java::lang::String("this is a string");
+			}
+
+			virtual void ForEachRemaining(const ::java::util::function::Consumer& arg0)
+			{
+				printf("ForEachRemaining[%p]!\n", this);
 			}
 
 		private:

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -363,6 +363,27 @@ int main(int,char**)
 		printf("Value of copy-assigned integer: %d\n", static_cast<jint>(integer));
 	}
 
+	// -------------------------------------------------------------
+	// Move semantics for String class
+	// -------------------------------------------------------------
+	{
+		jni::LocalFrame frame;
+
+		java::lang::String str("hello");
+		printf("Java string: %s\n", str.c_str());
+
+		java::lang::String str_moved("other");
+		str_moved = std::move(str);
+
+		if (static_cast<jobject>(str) != 0)
+		{
+			puts("str was supposed to be moved from when assigning");
+			abort();
+		}
+
+		printf("Moved string: %s\n", str_moved.c_str());
+	}
+
 	printf("%s\n", "EOP");
 
 	// print resolution of clock()


### PR DESCRIPTION
Makes C++ classes representing Java counterparts have move semantics for better performance.
Additionally fixes test build and adds Yamato CI to run tests.