### PR TITLE
Add an ability to override JNI->FindClass functionality

### DIFF
--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -107,16 +107,27 @@ static void ClearErrors()
 // --------------------------------------------------------------------------------------
 // Initialization and error functions (public)
 // --------------------------------------------------------------------------------------
-void Initialize(JavaVM& vm, CallbackOverrides* overrides )
+void Initialize(JavaVM& vm, const CallbackOverrides& overrides)
+{
+	Initialize(vm);
+	g_Overrides = (CallbackOverrides*)malloc(sizeof(CallbackOverrides));
+	memcpy(g_Overrides, &overrides, sizeof(CallbackOverrides));
+}
+
+void Initialize(JavaVM& vm)
 {
 	g_JavaVM = &vm;
-	g_Overrides = overrides;
+	g_Overrides = NULL;
 }
 
 void Shutdown()
 {
 	g_JavaVM = NULL;
-	g_Overrides = NULL;
+	if (g_Overrides != NULL)
+	{
+		free(g_Overrides);
+		g_Overrides = NULL;
+	}
 }
 
 Errno PeekError()

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -44,7 +44,7 @@ namespace jni
 #endif
 
 static JavaVM*              g_JavaVM;
-static CallbackOverrides*	g_Overrides;
+static CallbackOverrides*   g_Overrides;
 
 jobject kNull(0);
 

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -118,14 +118,10 @@ void Initialize(JavaVM& vm, CallbackOverrides* overrides)
 {
 	g_JavaVM = &vm;
 
-	if (overrides != NULL)
-	{
-		g_Overrides = *overrides;
-	}
-	else
-	{
-		ResetOverrides();
-	}
+	ResetOverrides();
+
+	if (overrides != NULL && overrides->FindClass != NULL)
+		g_Overrides.FindClass = overrides->FindClass;
 }
 
 void Shutdown()

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -43,7 +43,7 @@ namespace jni
 	};
 #endif
 
-static JavaVM*				g_JavaVM;
+static JavaVM*              g_JavaVM;
 static CallbackOverrides*	g_Overrides;
 
 jobject kNull(0);

--- a/JNIBridge.h
+++ b/JNIBridge.h
@@ -34,7 +34,7 @@ extern jobject kNull;
 // --------------------------------------------------------------------------------------
 void        Initialize(JavaVM& vm, const CallbackOverrides& overrides);
 void        Initialize(JavaVM& vm);
-void		Shutdown();
+void        Shutdown();
 
 Errno       CheckError();
 Errno       PeekError();

--- a/JNIBridge.h
+++ b/JNIBridge.h
@@ -12,6 +12,12 @@ typedef void* jvoid; // make it possible to return void
 
 namespace jni
 {
+	struct CallbackOverrides
+	{
+		typedef jclass(*FindClass)(JNIEnv*, const char*);
+
+		FindClass findClass;
+	};
 
 enum Errno
 {
@@ -26,7 +32,8 @@ extern jobject kNull;
 // --------------------------------------------------------------------------------------
 // Initialization and error functions
 // --------------------------------------------------------------------------------------
-void        Initialize(JavaVM& vm);
+void        Initialize(JavaVM& vm, CallbackOverrides* overrides = NULL);
+void		Shutdown();
 
 Errno       CheckError();
 Errno       PeekError();

--- a/JNIBridge.h
+++ b/JNIBridge.h
@@ -32,7 +32,8 @@ extern jobject kNull;
 // --------------------------------------------------------------------------------------
 // Initialization and error functions
 // --------------------------------------------------------------------------------------
-void        Initialize(JavaVM& vm, CallbackOverrides* overrides = NULL);
+void        Initialize(JavaVM& vm, const CallbackOverrides& overrides);
+void        Initialize(JavaVM& vm);
 void		Shutdown();
 
 Errno       CheckError();

--- a/JNIBridge.h
+++ b/JNIBridge.h
@@ -14,9 +14,9 @@ namespace jni
 {
 	struct CallbackOverrides
 	{
-		typedef jclass(*FindClass)(JNIEnv*, const char*);
+		typedef jclass(*FindClassFunc)(JNIEnv*, const char*);
 
-		FindClass findClass;
+		FindClassFunc FindClass;
 	};
 
 enum Errno
@@ -32,8 +32,7 @@ extern jobject kNull;
 // --------------------------------------------------------------------------------------
 // Initialization and error functions
 // --------------------------------------------------------------------------------------
-void        Initialize(JavaVM& vm, const CallbackOverrides& overrides);
-void        Initialize(JavaVM& vm);
+void        Initialize(JavaVM& vm, CallbackOverrides* overrides = NULL);
 void        Shutdown();
 
 Errno       CheckError();

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -1,3 +1,4 @@
+#include "Test.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -54,7 +55,7 @@ void AbortIfErrorsImpl(JNIEnv* env, const char* message, int line)
 	}
 }
 
-#define AbortIfErrors(Message) AbortIfErrorsImpl(env, Message, __LINE__);
+void TestOverrides(JavaVM* vm, JNIEnv* env);
 
 int main(int,char**)
 {
@@ -82,6 +83,11 @@ int main(int,char**)
 
 	JNIEnv* env = (JNIEnv*)envPtr;
 
+	// Custom tests
+	TestOverrides(vm, env);
+	// ... add more
+
+	// Generic tests
 	jni::Initialize(*vm);
 
 	// ------------------------------------------------------------------------

--- a/test/Test.h
+++ b/test/Test.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <jni.h>
+
+void AbortIfErrorsImpl(JNIEnv* env, const char* message, int line);
+#define AbortIfErrors(Message) AbortIfErrorsImpl(env, Message, __LINE__);

--- a/test/TestOverrides.cpp
+++ b/test/TestOverrides.cpp
@@ -1,0 +1,79 @@
+#include <jni.h>
+#include "API.h"
+#include "Test.h"
+#include <string.h>
+#include <assert.h>
+
+static jobject s_CustomClassLoader = 0;
+static jmethodID s_ClassForNameMethod = 0;
+static int s_ClassLoaderCallCount = 0;
+
+struct JNIOverrides
+{
+    typedef jclass(*FindClass)(JNIEnv*, const char*);
+
+    FindClass findClass;
+};
+
+jclass FindClass(JNIEnv* env, const char* name)
+{
+    // Taken from Unity code
+    env->ExceptionClear();
+    jclass clazz = env->FindClass("java/lang/Class");
+    jboolean initialize = JNI_TRUE;
+    jstring java_name = env->NewStringUTF(name);
+    jclass klass = (jclass)env->CallStaticObjectMethod(clazz, s_ClassForNameMethod, java_name, initialize, s_CustomClassLoader);
+    env->DeleteLocalRef(java_name);
+    env->DeleteLocalRef(clazz);
+    s_ClassLoaderCallCount++;
+    return klass;
+}
+
+void AllocateClassLoader(JNIEnv* env)
+{
+    jclass jniBridgeClass = env->FindClass("bitter/jnibridge/JNIBridge");
+    jclass classClass = env->GetObjectClass(jniBridgeClass);
+
+    // This piece of code taken from Unity (EntryPoint.cpp void InitJni(JavaVM* jvm, jobject obj, jobject context))
+    jclass classLoaderClass = env->FindClass("java/lang/ClassLoader");
+    jmethodID getClassLoaderMethod = env->GetMethodID(classClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
+    s_CustomClassLoader = env->NewGlobalRef(env->CallObjectMethod(jniBridgeClass, getClassLoaderMethod));
+    s_ClassForNameMethod = env->GetStaticMethodID(classClass, "forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;");
+
+    AbortIfErrors("Couldn't allocate class loader");
+}
+
+void DeallocateClassLoader(JNIEnv* env)
+{
+    env->DeleteGlobalRef(s_CustomClassLoader);
+    s_CustomClassLoader = 0;
+    s_ClassForNameMethod = 0;
+}
+
+void TestOverrides(JavaVM* vm, JNIEnv* env)
+{
+    AllocateClassLoader(env);
+
+    jni::CallbackOverrides overrides;
+    overrides.findClass = FindClass;
+    jni::Initialize(*vm, &overrides);
+    
+    int oldCallCount;
+    jclass klass;
+    // Note: need to use . instead of / 
+    oldCallCount = s_ClassLoaderCallCount;
+    klass = jni::FindClass("bitter.jnibridge.JNIBridge");
+    assert(s_ClassLoaderCallCount == 1 + oldCallCount && klass && "Failed to get bitter.jnibridge.JNIBridge class via class loader");
+
+    oldCallCount = s_ClassLoaderCallCount;
+    klass = jni::FindClass("java.lang.ClassLoader");
+    assert(s_ClassLoaderCallCount == 1 + oldCallCount && klass && "Failed to get java.lang.ClassLoader class via class loader");
+
+    klass = jni::FindClass("java.lang.ClassLoader2");
+    assert(klass == NULL && "We shouldn't suppose to find the class");
+    assert(env->ExceptionCheck() && "Was expecting exception to be set");
+    env->ExceptionClear();
+
+    DeallocateClassLoader(env);
+    jni::Shutdown();
+}


### PR DESCRIPTION
During the work with game activity integration, I noticed JNIEnv->FindClass stopped working (it doesn't find classes), because GameActivity creates pthread thread rather than Java thread for player loop.

The issue is this 
https://developer.android.com/training/articles/perf-jni#faq_FindClass
"This usually does what you want. You can get into trouble if you create a thread yourself (perhaps by calling pthread_create and then attaching it with AttachCurrentThread). Now there are no stack frames from your application. If you call FindClass from this thread, the JavaVM will start in the "system" class loader instead of the one associated with your application, so attempts to find app-specific classes will fail."


Luckily Unity caches a class loader which can help to workaround this issue.

This PR introduces a callback override, where you can tell JNIBridge to go through our custom classloader thus making it work again.