### PR TITLE
[case1403043]To add SensorManager to check if a device has a sensor o…

### DIFF
--- a/JniBridge.bee.cs
+++ b/JniBridge.bee.cs
@@ -62,6 +62,7 @@ class JniBridge
         "::android::hardware::input::InputManager",
         "::android::hardware::GeomagneticField",
         "::android::location::LocationManager",
+        "::android::hardware::SensorManager",
         "::android::media::AudioAttributes_Builder",
         "::android::media::AudioFocusRequest_Builder",
         "::android::media::AudioManager",


### PR DESCRIPTION
To resolve the case1403043(https://fogbugz.unity3d.com/f/cases/1403043), it should be checked whether a device has an Accelerometer sensor or not. Therefore, **SupportsAccelerometer** API for Android should be implemented which requires SensorManager class.