### PR TITLE
Proxy deletion related fixes

### DIFF
--- a/APIHelper.h
+++ b/APIHelper.h
@@ -77,6 +77,7 @@ public:
 		if (m_Ref == o.m_Ref)
 			return *this;
 
+		Release();
 		m_Ref = o.m_Ref;
 		o.m_Ref = nullptr;
 		return *this;

--- a/APIHelper.h
+++ b/APIHelper.h
@@ -85,10 +85,8 @@ public:
 	void Release()
 	{
 		if (m_Ref && !m_Ref->Release())
-		{
 			delete m_Ref;
-			m_Ref = NULL;
-		}
+		m_Ref = NULL;
 	}
 
 private:

--- a/APIHelper.h
+++ b/APIHelper.h
@@ -82,6 +82,15 @@ public:
 		return *this;
 	}
 
+	void Release()
+	{
+		if (m_Ref && !m_Ref->Release())
+		{
+			delete m_Ref;
+			m_Ref = NULL;
+		}
+	}
+
 private:
 	class RefCounter
 	{
@@ -111,15 +120,6 @@ private:
 	{
 		m_Ref = ref;
 		m_Ref->Aquire();
-	}
-
-	void Release()
-	{
-		if (m_Ref && !m_Ref->Release())
-		{
-			delete m_Ref;
-			m_Ref = NULL;
-		}
 	}
 
 private:

--- a/JniBridge.bee.cs
+++ b/JniBridge.bee.cs
@@ -147,7 +147,7 @@ class JniBridge
         foreach (var toolchain in androidToolchains)
         {
             var androidConfig = new NativeProgramConfiguration(codegen, toolchain, false);
-            var np = SetupJniBridgeStaticLib(generatedFilesAndroid, androidConfig, GetAndroidStaticLibParams(toolchain), androidZip);
+            var np = SetupJniBridgeStaticLib(generatedFilesAndroid, androidConfig, GetAndroidStaticLibParams(toolchain, codegen), androidZip);
             nativePrograms.Add(np);
         }
         var headers = SetupJniBridgeHeaders(generatedFilesAndroid, "android");
@@ -335,17 +335,18 @@ class JniBridge
         public Action<NativeProgram> specialConfiguration;
     }
 
-    static StaticLibParams GetAndroidStaticLibParams(ToolChain toolchain)
+    static StaticLibParams GetAndroidStaticLibParams(ToolChain toolchain, CodeGen codegen)
     {
+        var debugMode = codegen == CodeGen.Release ? DebugMode.None : DebugMode.IncludeDebugSymbols;
         Action<NativeProgram> specConfig =  (toolchain.Architecture is ARMv7Architecture)
             ? (np) =>
             {
                 np.CompilerSettingsForAndroid().Add(c => c.WithThumb(true));
-                np.CompilerSettingsForAndroid().Add(c => c.WithDebugMode(DebugMode.None));
+                np.CompilerSettingsForAndroid().Add(c => c.WithDebugMode(debugMode));
             }
             : (np) =>
             {
-                np.CompilerSettingsForAndroid().Add(c => c.WithDebugMode(DebugMode.None));
+                np.CompilerSettingsForAndroid().Add(c => c.WithDebugMode(debugMode));
             };
         return new StaticLibParams()
         {

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -137,7 +137,7 @@ void ProxyTracker::DeleteAllProxies()
 		std::swap(proxies, prox);
 	}
 	for (auto proxy : prox)
-		proxy->Disable();
+		proxy->DisableProxy();
 }
 
 }

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -4,6 +4,9 @@ namespace jni
 {
 
 jni::Class s_JNIBridgeClass("bitter/jnibridge/JNIBridge");
+#if !defined(DISABLE_PROXY_COUNTING)
+std::atomic<unsigned> ProxyObject::proxyCount;
+#endif
 
 JNIEXPORT jobject JNICALL Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_invoke(JNIEnv* env, jobject thiz, jlong ptr, jclass clazz, jobject method, jobjectArray args)
 {

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -145,9 +145,12 @@ void ProxyTracker::StopTracking(ProxyObject* obj)
 
 void ProxyTracker::DeleteAllProxies()
 {
-	std::lock_guard<std::mutex> guard(lock);
-	LinkedProxy* current = head;
-	head = NULL; // Destructor will call StopTracking, this will prevent it from looping through the whole list
+	LinkedProxy* current;
+	{
+		std::lock_guard<std::mutex> guard(lock);
+		current = head;
+		head = NULL; // Destructor will call StopTracking, this will prevent it from looping through the whole list
+	}
 	while (current != NULL)
 	{
 		LinkedProxy* previous = current;

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -155,7 +155,7 @@ void ProxyTracker::DeleteAllProxies()
 	{
 		LinkedProxy* previous = current;
 		current = current->next;
-		delete previous->obj;
+		previous->obj->Disable();
 		delete previous;
 	}
 }

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -23,11 +23,6 @@ JNIEXPORT jobject JNICALL Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_in
 	return proxy->__Invoke(clazz, methodID, args);
 }
 
-JNIEXPORT void JNICALL Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_delete(JNIEnv* env, jobject thiz, jlong ptr)
-{
-	delete (ProxyInvoker*)ptr;
-}
-
 bool ProxyInvoker::__Register()
 {
 	jni::LocalScope frame;
@@ -39,10 +34,9 @@ bool ProxyInvoker::__Register()
 
 	JNINativeMethod nativeProxyFunction[] = {
 		{invokeMethodName, invokeMethodSignature, (void*) Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_invoke},
-		{deleteMethodName, deleteMethodSignature, (void*) Java_bitter_jnibridge_JNIBridge_00024InterfaceProxy_delete}
 	};
 
-	if (nativeProxyClass) jni::GetEnv()->RegisterNatives(nativeProxyClass, nativeProxyFunction, 2); // <-- fix this
+	if (nativeProxyClass) jni::GetEnv()->RegisterNatives(nativeProxyClass, nativeProxyFunction, 1);
 	return !jni::CheckError();
 }
 

--- a/Proxy.h
+++ b/Proxy.h
@@ -31,7 +31,14 @@ protected:
 
 template <class RefAllocator, class ...TX>
 class ProxyGenerator : public ProxyObject, public TX::__Proxy...
-{	
+{
+public:
+	void DisableProxy() override
+	{
+		DisableInstance(__ProxyObject());
+		m_ProxyObject.Release();
+	}
+
 protected:
 	ProxyGenerator() : m_ProxyObject(CreateInstance())
 	{
@@ -40,12 +47,6 @@ protected:
 	virtual ~ProxyGenerator()
 	{
 		DisableInstance(__ProxyObject());
-	}
-
-	void DisableProxy() override
-	{
-		DisableInstance(__ProxyObject());
-		m_ProxyObject.Release();
 	}
 
 	::jobject __ProxyObject() const override { return m_ProxyObject; }

--- a/Proxy.h
+++ b/Proxy.h
@@ -80,7 +80,7 @@ protected:
 		DisableInstance(__ProxyObject());
 	}
 
-	virtual ::jobject __ProxyObject() const { return m_ProxyObject; }
+	::jobject __ProxyObject() const override { return m_ProxyObject; }
 
 private:
 	inline jobject CreateInstance()
@@ -90,7 +90,7 @@ private:
 	}
 
 	template<typename... Args> inline void DummyInvoke(Args&&...) {}
-	virtual bool __InvokeInternal(jclass clazz, jmethodID mid, jobjectArray args, jobject* result)
+	bool __InvokeInternal(jclass clazz, jmethodID mid, jobjectArray args, jobject* result) override
 	{
 		bool success = false;
 		DummyInvoke(ProxyObject::__TryInvoke(clazz, mid, args, &success, result), TX::__Proxy::__TryInvoke(clazz, mid, args, &success, result)...);

--- a/Proxy.h
+++ b/Proxy.h
@@ -13,6 +13,7 @@ class ProxyObject : public virtual ProxyInvoker
 // Dispatch invoke calls
 public:
 	virtual jobject __Invoke(jclass clazz, jmethodID mid, jobjectArray args);
+	virtual void Disable() = 0;
 // Cleanup all proxy objects
 	static void DeleteAllProxies();
 
@@ -71,6 +72,11 @@ protected:
 	virtual ~ProxyGenerator()
 	{
 		proxyTracker.StopTracking(this);
+		DisableInstance(__ProxyObject());
+	}
+
+	virtual void Disable()
+	{
 		DisableInstance(__ProxyObject());
 	}
 

--- a/Proxy.h
+++ b/Proxy.h
@@ -14,7 +14,7 @@ class ProxyObject : public virtual ProxyInvoker
 // Dispatch invoke calls
 public:
 	virtual jobject __Invoke(jclass clazz, jmethodID mid, jobjectArray args);
-	virtual void Disable() = 0;
+	virtual void DisableProxy() = 0;
 // Cleanup all proxy objects
 	static void DeleteAllProxies();
 
@@ -67,7 +67,7 @@ protected:
 		DisableInstance(__ProxyObject());
 	}
 
-	void Disable() override
+	void DisableProxy() override
 	{
 		DisableInstance(__ProxyObject());
 	}

--- a/Proxy.h
+++ b/Proxy.h
@@ -70,6 +70,7 @@ protected:
 	void DisableProxy() override
 	{
 		DisableInstance(__ProxyObject());
+		m_ProxyObject.Release();
 	}
 
 	::jobject __ProxyObject() const override { return m_ProxyObject; }

--- a/Proxy.h
+++ b/Proxy.h
@@ -75,7 +75,7 @@ protected:
 		DisableInstance(__ProxyObject());
 	}
 
-	virtual void Disable()
+	void Disable() override
 	{
 		DisableInstance(__ProxyObject());
 	}

--- a/Proxy.h
+++ b/Proxy.h
@@ -2,6 +2,7 @@
 
 #include "API.h"
 #include <mutex>
+#include <vector>
 
 namespace jni
 {
@@ -47,16 +48,7 @@ public:
 	void DeleteAllProxies();
 
 private:
-	class LinkedProxy
-	{
-	public:
-		LinkedProxy(ProxyObject* target, LinkedProxy* link) : obj(target), next(link) {}
-
-		ProxyObject* obj;
-		LinkedProxy* next;
-	};
-
-	LinkedProxy* head;
+	std::vector<ProxyObject*> proxies;
 	std::mutex lock;
 };
 

--- a/jnibridge/bitter/jnibridge/JNIBridge.java
+++ b/jnibridge/bitter/jnibridge/JNIBridge.java
@@ -6,7 +6,6 @@ import java.lang.invoke.*;
 public class JNIBridge
 {
 	static native Object invoke(long ptr, Class clazz, Method method, Object[] args);
-	static native void   delete(long ptr);
 
 	static Object newInterfaceProxy(final long ptr, final Class[] interfaces)
 	{
@@ -82,16 +81,6 @@ public class JNIBridge
 					else
 						throw e;
 				}
-			}
-		}
-
-		public void finalize()
-		{
-			synchronized (m_InvocationLock)
-			{
-				if (m_Ptr == 0)
-					return;
-				JNIBridge.delete(m_Ptr);
 			}
 		}
 

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -424,6 +424,31 @@ int main(int argc, char** argv)
 	AbortIfErrors("Failures with Proxy Object Test");
 
 	// -------------------------------------------------------------
+	// Proxy tracking
+	// -------------------------------------------------------------
+	{
+		struct RunnableImpl : jni::Proxy<Runnable>
+		{
+			virtual ~RunnableImpl() {printf("%s\n", "RunnableImpl destroyed");}
+			virtual void Run() {printf("%s\n", "hello world!!!!"); }
+		};
+		RunnableImpl* runnable;
+		RunnableImpl onStackRunnable;
+		{
+			jni::LocalScope frame;
+			runnable = new RunnableImpl;
+		}
+
+		// deleting proxies
+		printf("%s\n", "Deleting all proxies");
+		jni::ProxyObject::DeleteAllProxies();
+		printf("%s\n", "All proxies are deleted");
+		delete runnable;
+	}
+
+	AbortIfErrors("Failures with Proxy tracking Test");
+
+	// -------------------------------------------------------------
 	// Move semantics
 	// -------------------------------------------------------------
 	{

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -304,13 +304,13 @@ int main(int argc, char** argv)
 	// -------------------------------------------------------------
 	struct KillMePleazeRunnable : jni::WeakProxy<Runnable>
 	{
-		virtual ~KillMePleazeRunnable() { printf("%s\n", "KillMePleazeRunnable");}
+		virtual ~KillMePleazeRunnable() { printf("%s\n", "KillMePleazeRunnable destroyed");}
 		virtual void Run() { }
 	};
 
 	{
 		jni::LocalScope frame;
-		new KillMePleazeRunnable;
+		KillMePleazeRunnable destructorShoudDisableCallIntoNative;
 	}
 	AbortIfErrors("Failures with Weak Proxy");
 

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
 
 	JavaVMOption options[2];
 	options[0].optionString = classPath;
-	options[1].optionString = "-Xcheck:jni";
+	options[1].optionString = const_cast<char*>("-Xcheck:jni");
 
 	vm_args.options = options;
 	vm_args.nOptions = 2;
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
 		java::lang::Integer integers4[] = { 1, 2, 3, 4 };
 		jni::Array<jint> test05(4, integers4);
 		for (int i = 0; i < test05.Length(); ++i)
-			printf("ArrayTest05[%ld],", (jint)test05[i]);
+			printf("ArrayTest05[%d],", (int)test05[i]);
 		printf("\n");
 
 		jni::Array<java::lang::Integer> test10(4, 4733);

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -424,31 +424,6 @@ int main(int argc, char** argv)
 	AbortIfErrors("Failures with Proxy Object Test");
 
 	// -------------------------------------------------------------
-	// Proxy tracking
-	// -------------------------------------------------------------
-	{
-		struct RunnableImpl : jni::Proxy<Runnable>
-		{
-			virtual ~RunnableImpl() {printf("%s\n", "RunnableImpl destroyed");}
-			virtual void Run() {printf("%s\n", "hello world!!!!"); }
-		};
-		RunnableImpl* runnable;
-		RunnableImpl onStackRunnable;
-		{
-			jni::LocalScope frame;
-			runnable = new RunnableImpl;
-		}
-
-		// deleting proxies
-		printf("%s\n", "Deleting all proxies");
-		jni::ProxyObject::DeleteAllProxies();
-		printf("%s\n", "All proxies are deleted");
-		delete runnable;
-	}
-
-	AbortIfErrors("Failures with Proxy tracking Test");
-
-	// -------------------------------------------------------------
 	// Move semantics
 	// -------------------------------------------------------------
 	{

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -258,21 +258,23 @@ int main(int argc, char** argv)
 		virtual void Run() {printf("%s\n", "hello world!!!!"); }
 	};
 
-	PretendRunnable pretendRunnable;
-	Runnable runnable = pretendRunnable;
+	{
+		PretendRunnable pretendRunnable;
+		Runnable runnable = pretendRunnable;
 
-	Thread     thread(pretendRunnable);
-	thread.Start();
-	thread.Join();
+		Thread     thread(pretendRunnable);
+		thread.Start();
+		thread.Join();
 
-	runnable.Run();
+		runnable.Run();
 
-	// Make sure we don't get crashes from deleting the native object.
-	PretendRunnable* pretendRunnable2 = new PretendRunnable;
-	Runnable runnable2 = *pretendRunnable2;
-	runnable2.Run();
-	delete pretendRunnable2;
-	runnable2.Run(); // <-- should not log anything
+		// Make sure we don't get crashes from deleting the native object.
+		PretendRunnable* pretendRunnable2 = new PretendRunnable;
+		Runnable runnable2 = *pretendRunnable2;
+		runnable2.Run();
+		delete pretendRunnable2;
+		runnable2.Run(); // <-- should not log anything
+	}
 
 	// -------------------------------------------------------------
 	// Performance Proxy Test


### PR DESCRIPTION
Proxy-related changes:
- drop automatic deletion of WeakProxy on finalize() (from now you have to manually manage it's lifetime); this is a very bad idea for few reasons:
  - it uses delete operator to destroy the proxy, so if you create C++ object in other way than operator new, you have to ensure C++ object is destroyed before Java object is finalized, otherwise crash
  - with C++ object having a weak reference to Java object, you have no way of controlling when the later one gets GCed
  - found 2 cases where we use WeakProxy in Unity code, one correctly uses new, other does not; the fact that you pretty much must use new is not evident, hence disaster waiting to happen
- ProxyTracker::DeleteAllProxies() used to delete each proxy while under mutex lock, where destructor of proxy would unregister itself leading to deadlock; proxies no longer deleted, only disabled, so problem solved
- Proxies are no longer tracket genericly; after struggling with making unity tests pass, I conclude that this is a bad thing in general. All proxy object should be properly destroyed instead of having such generic destruction that it is not clear when it's safe to call (should be called after proxies are guaranteed to no longer serve a useful purpose, yet the object still alive in valid memory)

Not related changes:
- Fixed a couple of warnings in test project
- Switching codegen to debug will build library with debug symbols (useful for local)

Katana green (couple proxies temporarily commented out in unity, cause they are known leaks to fix).