### PR TITLE
[UUM-32514] To update SystemInfo.deviceName for API Level 32 or higher

### DIFF
--- a/JniBridge.bee.cs
+++ b/JniBridge.bee.cs
@@ -80,6 +80,7 @@ class JniBridge
         "::android::os::PowerManager",
         "::android::os::Process",
         "::android::os::Vibrator",
+        "::android::provider::Settings_Global",
         "::android::provider::Settings_Secure",
         "::android::provider::Settings_System",
         "::android::telephony::TelephonyManager",


### PR DESCRIPTION
**Jira Link:**
https://jira.unity3d.com/browse/UUM-32514


**Issue:**
When users try to get `SystemInfo.deviceName` on Android12 or higher, it returns the error message **"JNI:GetDeviceName:java.lang.SecurityException: Settings key: <bluetooth_name> is only readable to apps with targetSdkVersion lower than or equal to: 31"**

**Solution:**
To follow the advice described in the ticket, added `::android::provider::Settings_Global` to  JniBridge.bee.cs file.


