### PR TITLE
Bump to API 34

### DIFF
--- a/JniBridge.bee.cs
+++ b/JniBridge.bee.cs
@@ -37,7 +37,7 @@ using System.Linq;
 
 class JniBridge
 {
-    const string kAndroidApi = "android-31";
+    const string kAndroidApi = "android-34";
     const string kJavaVersion = "17";
 
     static class Platform


### PR DESCRIPTION
Need to gain access to https://developer.android.com/reference/android/view/WindowMetrics#getDensity() which became available only in API 34, part of https://jira.unity3d.com/browse/PLAT-9020