### PR TITLE
Expose ::android::view::WindowInsets_Type

### DIFF
--- a/JniBridge.bee.cs
+++ b/JniBridge.bee.cs
@@ -91,6 +91,7 @@ class JniBridge
         "::android::view::Display",
         "::android::view::Gravity",
         "::android::view::SurfaceView",
+        "::android::view::WindowInsets_Type",
         "::android::view::WindowManager",
         "::android::webkit::MimeTypeMap",
         "::android::widget::CheckBox",


### PR DESCRIPTION
Need it for this code
```
            bool decorFitsSystemWindows = !(fullscreen || s_RenderOutsideSafeArea);
            activity.GetWindow().SetDecorFitsSystemWindows(decorFitsSystemWindows);

            android::view::WindowInsetsController controller = activity.GetWindow().GetInsetsController();
            if (controller)
            {
                static int s_Insets = android::view::WindowInsets_Type::StatusBars() |
                    android::view::WindowInsets_Type::NavigationBars();

                if (decorFitsSystemWindows)
                {
                    controller.Show(s_Insets);
                }
                else
                {
                    controller.Hide(s_Insets);
                    controller.SetSystemBarsBehavior(android::view::WindowInsetsController::fBEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE());
                }
            }
```